### PR TITLE
molecules/card のz-index, line-heightを修正

### DIFF
--- a/src/components/molecules/card/card.scss
+++ b/src/components/molecules/card/card.scss
@@ -32,11 +32,13 @@
   flex-direction: column;
   background-color: $white_smoke;
   padding: 32px;
+  z-index: 1;
 }
 
 .card-text {
   font-size: $fontsize-s;
   margin-bottom: 30px;
+  line-height: 33px;
 }
 
 @media screen and (min-width: $breakpoint-md) {


### PR DESCRIPTION
organisms-cardsを作成中、z-indexでの不具合と、line-heightの値がfigmaと違ったので修正しました。

## セルフチェック
- [O] お手本通りの見た目であるか　ホバー時の挙動、レスポンシブ対応など要確認
- [O] ブランチ名、ファイル名、クラス名、インデントなど、コーディング規則を逸脱していないか
- [O] 記述の重複はないか

リンク
[https://626e03ce97ce92004af16925-qocbeqkwji.chromatic.com/?path=/story/molecules-card--card](chromatic上の該当ページへのリンクを貼る)
